### PR TITLE
Introduce linter error when pubdev not sorted

### DIFF
--- a/application/analysis_options.yaml
+++ b/application/analysis_options.yaml
@@ -1,6 +1,7 @@
 include: package:flutter_lints/flutter.yaml
 linter:
   rules:
+    sort_pub_dependencies: true
     depend_on_referenced_packages: false
 analyzer:
   exclude: [
@@ -11,6 +12,7 @@ analyzer:
       'lib/**.config.dart'
   ]
   errors:
+    sort_pub_dependencies: error
     missing_required_param: error
     parameter_assignments: error
     missing_return: error

--- a/application/pubspec.yaml
+++ b/application/pubspec.yaml
@@ -20,8 +20,6 @@ environment:
 # the latest version available on pub.dev. To see which dependencies have newer
 # versions available, run `flutter pub outdated`.
 dependencies:
-  flutter:
-    sdk: flutter
   another_flushbar: 1.12.29
   audio_session: 0.1.13
   auto_route: 5.0.4
@@ -43,6 +41,8 @@ dependencies:
   firebase_database: 10.0.9
   firebase_remote_config: 3.0.9
   flip_board: 0.6.1
+  flutter:
+    sdk: flutter
   flutter_bloc: 8.1.1
   flutter_email_sender: 5.2.0
   flutter_link_previewer: 3.2.0
@@ -51,9 +51,9 @@ dependencies:
   get_it: 7.2.0
   hive: 2.2.3
   injectable: 2.1.0
+  json_annotation: 4.8.0
   just_audio: 0.9.31
   just_audio_background: 0.0.1-beta.9
-  json_annotation: 4.8.0
   meta: 1.8.0
   open_store: 0.5.0
   package_info: 2.0.2
@@ -62,23 +62,22 @@ dependencies:
   scroll_to_index: 3.0.1
   share_plus: 6.3.0
   sprintf: 7.0.0
-  super_rich_text: 1.0.0
   stream_transform: 2.1.0
+  super_rich_text: 1.0.0
   transformer_page_view: 0.1.6
+  update_available: 2.2.0
   url_launcher: 6.1.8
   visibility_detector: 0.3.3
   watcher: 1.0.2
-  update_available: 2.2.0
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
-
   auto_route_generator: 5.0.3
-  build_runner: 2.3.0
   bloc_test: 9.1.0
+  build_runner: 2.3.0
   flutter_launcher_icons: 0.11.0
   flutter_lints: 2.0.1
+  flutter_test:
+    sdk: flutter
   freezed: 2.3.2
   hive_generator: 2.0.0
   injectable_generator: 2.1.3


### PR DESCRIPTION
### What 🕵️ 🔍

- Introduce linter error when pubdev dependencies are not sorted

----------

### How to test 🥼 🔬

- [ ] try to move some pub dependencies in the list
- [ ] verify that there is an error

----------
