### PR TITLE
feat: hide random tale button when homePage enabled

### DIFF
--- a/application/lib/presentation/view/screen/main/page/tales/manager/tales_page_manager.dart
+++ b/application/lib/presentation/view/screen/main/page/tales/manager/tales_page_manager.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:collection/collection.dart';
 import 'package:bloc/bloc.dart';
+import 'package:mobile_app/domain/feature_flag/feature.dart';
+import 'package:mobile_app/domain/feature_flag/feature_flag_provider.dart';
 import 'package:mobile_app/domain/model/rating/rating_data.dart';
 import 'package:mobile_app/domain/model/sort_and_filter/data/sort_and_filter_open_type.dart';
 import 'package:mobile_app/domain/model/tale/value_object/tale_name.dart';
@@ -55,6 +57,7 @@ class TalesPageManager extends Cubit<TalesPageState> {
   final Mapper<TaleFilterType, StringSingleLine> _filterTypeToNameMapper;
   final Mapper<TaleFilterType, SvgAssetGraphic> _filterTypeToIconMapper;
   final Mapper<TaleSortType, StringSingleLine> _sortTypeToNameMapper;
+  final FeatureFlagProvider _featureFlagProvider;
   final Tracker _tracker;
 
   TalesPageManager(
@@ -73,6 +76,7 @@ class TalesPageManager extends Cubit<TalesPageState> {
     this._filterTypeToNameMapper,
     this._sortTypeToNameMapper,
     this._filterTypeToIconMapper,
+    this._featureFlagProvider,
     this._tracker,
   ) : super(const TalesPageState.initial()) {
     _init();
@@ -152,10 +156,12 @@ class TalesPageManager extends Cubit<TalesPageState> {
       _sortType,
       _sortTypeToNameMapper.map(_sortType),
     );
+    final homePageEnabled = _featureFlagProvider.isEnabled(Feature.homePage);
     final newState = TalesPageState.ready(
       filterData: filterData,
       sortData: sortData,
       tales: List.from(filteredAndSorted),
+      showRandom: !homePageEnabled,
     );
     emit(newState);
   }

--- a/application/lib/presentation/view/screen/main/page/tales/manager/tales_page_state.dart
+++ b/application/lib/presentation/view/screen/main/page/tales/manager/tales_page_state.dart
@@ -8,5 +8,6 @@ abstract class TalesPageState with _$TalesPageState {
     required TaleFilterItemData filterData,
     required TaleSortItemData sortData,
     required List<TalesPageItemData> tales,
+    required bool showRandom,
   }) = TalesPageStateReady;
 }

--- a/application/lib/presentation/view/screen/main/page/tales/tales_page.dart
+++ b/application/lib/presentation/view/screen/main/page/tales/tales_page.dart
@@ -63,7 +63,7 @@ class _TalesPageState extends State<TalesPage>
     );
     final bottomBar = Positioned.fill(
       top: null,
-      child: _createBottomButtons(),
+      child: _createBottomButtons(showRandom: state.showRandom),
     );
     return Stack(
       children: [
@@ -106,12 +106,13 @@ class _TalesPageState extends State<TalesPage>
         isFavList: filterType.isFav,
       );
 
-  Widget _createBottomButtons() {
+  Widget _createBottomButtons({required bool showRandom}) {
     final buttons = TalesPageBottomButtons(
       onFilterPressed: _manager.onFilterPressed,
       onSortPressed: _manager.onSortPressed,
       onRandomPressed: _manager.onRandomTalePressed,
       onSearchPressed: _manager.onSearchPressed,
+      showRandom: showRandom,
     );
     return HideWhenScroll(
       controller: _scrollController,

--- a/application/lib/presentation/view/screen/main/page/tales/widget/tales_page_bottom_buttons.dart
+++ b/application/lib/presentation/view/screen/main/page/tales/widget/tales_page_bottom_buttons.dart
@@ -9,6 +9,7 @@ class TalesPageBottomButtons extends StatelessWidget {
   final VoidCallback onSortPressed;
   final VoidCallback onSearchPressed;
   final VoidCallback onRandomPressed;
+  final bool showRandom;
 
   const TalesPageBottomButtons({
     Key? key,
@@ -16,6 +17,7 @@ class TalesPageBottomButtons extends StatelessWidget {
     required this.onSortPressed,
     required this.onSearchPressed,
     required this.onRandomPressed,
+    required this.showRandom,
   }) : super(key: key);
 
   @override
@@ -23,7 +25,7 @@ class TalesPageBottomButtons extends StatelessWidget {
     final row = Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        _createRandom(),
+        if (showRandom) _createRandom(),
         _createFilter(),
         _createSort(),
         _createSearch(),


### PR DESCRIPTION
### What 🕵️ 🔍

- hide random tale button from the `talesPage` when homePage enabled

----------

### How to test 🥼 🔬

- [ ] run the app
- [ ] open tales page
- [ ] verify there is no random button
- [ ] disable feature flag `homePage`
- [ ] restart app
- [ ] verify the random button is there

----------

### Screenshots 📸 📱

| Before | After  |
| ------ | ------ |
|  <img width="280" src="https://user-images.githubusercontent.com/12133914/224473062-4b50fd97-2136-4afe-90a9-014724838f56.png">  |<img width="280" src="https://user-images.githubusercontent.com/12133914/224473066-9199ad19-ca86-4983-9d5b-a8a831d2083d.png">|


----------

### References 📝 🔗

- [TASK](<!-- (add basecamp link here) -->)

----------