### PR TITLE
feat: fix missing tracking event in peoplePageManager

### DIFF
--- a/application/lib/presentation/view/screen/main/page/people/manager/people_page_manager.dart
+++ b/application/lib/presentation/view/screen/main/page/people/manager/people_page_manager.dart
@@ -71,7 +71,7 @@ class PeoplePageManager extends Cubit<PeoplePageState> {
   }
 
   void onPersonPressed(Person person) {
-    _tracker.event(TrackingEvents.peoplePageFavPressed);
+    _tracker.event(TrackingEvents.peoplePagePersonPressed);
     final role = _currentRole;
     if (role != null) {
       final event = TrackingEvents.getPeoplePagePersonPressedByRole(role);


### PR DESCRIPTION
### What 🕵️ 🔍

- fix missing tracking event in peoplePageManager

----------

### How to test 🥼 🔬

- [ ] open `peoplePage`
- [ ] click on the person fav btn - verify correct event tracked in console 
- [ ] click on the person  - verify correct event tracked in console

----------

### References 📝 🔗

- [TASK](https://www.notion.so/kazky/Event-not-tracked-856ec2a9f9fb42e09387672434ffae81?pvs=4)

----------