### PR TITLE
fix: downgrade just_audio_background dependency due to bug

### DIFF
--- a/application/lib/presentation/resource/string/string_res.dart
+++ b/application/lib/presentation/resource/string/string_res.dart
@@ -411,6 +411,9 @@ class _StringResEmail {
 }
 
 class _StringResWhatsNew {
+  String get bugfixAudioPlayer =>
+      'Виправили критичну помилку з програванням аудіо';
+
   String get newCountdownTimeItems => 'Таймер для автоматичної зупинки';
 
   String get newCountdownTimeItemsDesc =>

--- a/application/lib/presentation/view/screen/whats_new/manager/whats_new_data.dart
+++ b/application/lib/presentation/view/screen/whats_new/manager/whats_new_data.dart
@@ -1,5 +1,12 @@
 part of 'whats_new_screen_manager.dart';
 
+VersionChanges _get5_6_1() => VersionChanges(
+      _version('5.6.1'),
+      [
+        _item('👩🏻‍🔧 🎵 ${R.strings.whatsNew.bugfixAudioPlayer}'),
+      ],
+    );
+
 VersionChanges _get5_6_0({required bool isHomePageEnabled}) => VersionChanges(
       _version('5.6.0'),
       [

--- a/application/lib/presentation/view/screen/whats_new/manager/whats_new_screen_manager.dart
+++ b/application/lib/presentation/view/screen/whats_new/manager/whats_new_screen_manager.dart
@@ -35,6 +35,7 @@ class WhatsNewScreenManager extends Cubit<WhatsNewScreenState> {
   void init() {
     final isHomePageEnabled = _featureFlagProvider.isEnabled(Feature.homePage);
     final changes = [
+      _get5_6_1(),
       _get5_6_0(isHomePageEnabled: isHomePageEnabled),
       _get5_5_4(),
       _get5_5_0(),

--- a/application/pubspec.yaml
+++ b/application/pubspec.yaml
@@ -53,7 +53,7 @@ dependencies:
   injectable: 2.1.0
   json_annotation: 4.8.0
   just_audio: 0.9.31
-  just_audio_background: 0.0.1-beta.9
+  just_audio_background: 0.0.1-beta.8
   meta: 1.8.0
   open_store: 0.5.0
   package_info: 2.0.2


### PR DESCRIPTION
### What 🕵️ 🔍

- downgrade just_audio_background dependency due to bug

----------

### References 📝 🔗

- [bug](https://console.firebase.google.com/u/0/project/tales-8f587/crashlytics/app/android:ua.andriyantonov.tales/issues/74cde5831fe38aa5a871aca61a71ee48?time=last-seven-days&sessionEventKey=640CE733033F0001193517249FFCE90F_1787836953655091499)

----------